### PR TITLE
Fix some bugs caused by dependency updates

### DIFF
--- a/lib/modelproxy.js
+++ b/lib/modelproxy.js
@@ -113,7 +113,12 @@ ModelProxy.prototype = {
                     args[ k ] = data;
 
                     // concat setcookie for cookie rewriting
-                    setcookies = setcookies.concat( setcookie );
+
+                    //BUG fixed by Chion82 <sdspeedonion@gmail.com>
+                    //undefined cookie is passed to the callback
+                    if (setcookie)
+                        setcookies = setcookies.concat( setcookie );
+                    
                     args.push( setcookies );
 
                     // push the set-cookies as the last parameter for the callback function. 

--- a/lib/proxyfactory.js
+++ b/lib/proxyfactory.js
@@ -121,7 +121,10 @@ Proxy.prototype = {
             port: self._opt.port,
             path: self._opt.path,
             method: self._opt.method,
-            headers: { 'Cookie': cookie }
+            //BUG fixed by Chion82 <sdspeedonion@gmail.com>
+            //Occasionally cookie is undifined, causing requests fail with parameters error
+            //when calling setHeader() with the latest dependencies.
+            headers: { 'Cookie': cookie?cookie:'' }
         };
         var querystring = self._queryStringify( params );
 
@@ -136,7 +139,14 @@ Proxy.prototype = {
         } else if ( self._opt.method === 'GET' ) {
             options.path += '?' + querystring;
         }
+
+        //BUG fixed by Chion82 <sdspeedonion@gmail.com>
+        //self._opt.encoding is undifined
+        if (!self._opt.encoding)
+            self._opt.encoding = 'UTF-8';
+       
         var req = http.request( options, function( res ) {
+
             var timer = setTimeout( function() {
                 errCallback( new Error( 'timeout' ) );
             }, self._opt.timeout || 5000 );


### PR DESCRIPTION
Initially the library worked perfectly when running in mock mode in my environment. But when running in online mode, it threw serial uncaught exceptions mainly caused by undefined variables. I dug deep into the source code and found a ```headers``` containing an undefined ```cookie``` was passed to the ```http.request()```, which caused the fatal errors. I guess that passing an undefined variable as a header parameter is OK in the past but is deprecated by now because of dependency updates, and that may explain a lot. In addition, I change the ```setcookies``` logic to avoid automatically generating the ```Set-Cookie``` header like  ```cookie1=abc; cookie2=bcd; undefined```. Now it should be something like  ```cookie1=abc; cookie2=bcd;```